### PR TITLE
fix: include demo image

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include textual_image/gracehopper.jpg


### PR DESCRIPTION
It fixes #37 :

```shell
python -m textual_image
...
FileNotFoundError: [Errno 2] No such file or directory: '.../site-packages/textual_image/gracehopper.jpg'
```