### PR TITLE
feat: install textual-image script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,9 @@ dev = [
     "typos",
 ]
 
+[project.scripts]
+textual-image = "textual_image.__main__:main"
+
 [tool.setuptools.packages.find]
 include = ["textual_image*"]
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,8 +1,8 @@
-from importlib import import_module, reload
 from unittest import skipIf, skipUnless
 from unittest.mock import patch
 
 from tests.data import TEXTUAL_ENABLED
+from textual_image.__main__ import main
 
 
 @skipUnless(TEXTUAL_ENABLED, "Textual support disabled")
@@ -10,22 +10,22 @@ def test_main() -> None:
     with patch("sys.argv", ["unittest", "rich"]):
         with patch("textual_image.demo.renderable.run") as run_rich:
             with patch("textual_image.demo.widget.run") as run_textual:
-                main = import_module("textual_image.__main__")
+                main()
     assert run_rich.called
     assert not run_textual.called
 
     with patch("sys.argv", ["unittest", "textual"]):
         with patch("textual_image.demo.renderable.run") as run_rich:
             with patch("textual_image.demo.widget.run") as run_textual:
-                reload(main)
+                main()
     assert not run_rich.called
     assert run_textual.called
 
     with patch("sys.argv", ["unittest", "textual"]):
         with patch("textual_image.demo.renderable.run") as run_rich:
             with patch("textual_image.demo.widget.run") as run_textual:
-                with patch("importlib.util.find_spec", return_value=None):
-                    reload(main)
+                with patch("textual_image.demo.cli.find_spec", return_value=None):
+                    main()
     assert not run_rich.called
     assert not run_textual.called
 
@@ -34,12 +34,12 @@ def test_main() -> None:
 def test_main_rich_only() -> None:
     with patch("sys.argv", ["unittest", "rich"]):
         with patch("textual_image.demo.renderable.run") as run_rich:
-            main = import_module("textual_image.__main__")
+            main()
     assert run_rich.called
 
     with patch("sys.argv", ["unittest", "textual"]):
         with patch("textual_image.demo.renderable.run") as run_rich:
             with patch("sys.stderr") as stderr:
-                reload(main)
+                main()
     assert stderr.write.called
     assert not run_rich.called

--- a/textual_image/__main__.py
+++ b/textual_image/__main__.py
@@ -2,29 +2,9 @@
 
 """Run the textual_image demo."""
 
-import sys
-from argparse import ArgumentParser
-from importlib.util import find_spec
+from textual_image.demo.cli import main
 
-from textual_image.demo.renderable import RENDERING_METHODS
+__all__ = ["main"]
 
-textual_available = bool(find_spec("textual"))
-default_mode = "rich" if find_spec("textual") is None else "textual"
-
-parser = ArgumentParser(description="Demo the capabilities of textual-image")
-parser.add_argument("mode", choices=["rich", "textual"], nargs="?", default=default_mode)
-parser.add_argument("-m", "--method", choices=RENDERING_METHODS.keys(), default="auto")
-arguments = parser.parse_args()
-
-if arguments.mode == "rich":
-    from textual_image.demo.renderable import run as run_rich_demo
-
-    run_rich_demo(arguments.method)
-elif not textual_available:
-    sys.stderr.write(
-        "Optional Textual dependency not available. Install this package as `textual-image[textual]` for Textual support."
-    )
-else:
-    from textual_image.demo.widget import run as run_textual_demo
-
-    run_textual_demo(arguments.method)
+if __name__ == "__main__":
+    main()

--- a/textual_image/demo/cli.py
+++ b/textual_image/demo/cli.py
@@ -1,0 +1,33 @@
+"""CLI interface for the demo."""
+
+import sys
+from argparse import ArgumentParser
+from importlib.util import find_spec
+
+from textual_image.demo.renderable import RENDERING_METHODS
+
+__all__ = ["main"]
+
+
+def main() -> None:
+    """Entry point for the textual-image script."""
+    textual_available = bool(find_spec("textual"))
+    default_mode = "rich" if find_spec("textual") is None else "textual"
+
+    parser = ArgumentParser(description="Demo the capabilities of textual-image")
+    parser.add_argument("mode", choices=["rich", "textual"], nargs="?", default=default_mode)
+    parser.add_argument("-m", "--method", choices=RENDERING_METHODS.keys(), default="auto")
+    arguments = parser.parse_args()
+
+    if arguments.mode == "rich":
+        from textual_image.demo.renderable import run as run_rich_demo
+
+        run_rich_demo(arguments.method)
+    elif not textual_available:
+        sys.stderr.write(
+            "Optional Textual dependency not available. Install this package as `textual-image[textual]` for Textual support."
+        )
+    else:
+        from textual_image.demo.widget import run as run_textual_demo
+
+        run_textual_demo(arguments.method)


### PR DESCRIPTION
Enable running just `textual-image` in addition to `python -m textual_image`:

Before (without the commit):

```shell
uvx --from 'textual-image' -- python -m textual_image
```

After (with the patch):

```shell
uvx textual-image
```

It fixes #39 