### PR TITLE
feat: add byte stream support

### DIFF
--- a/tests/renderable/test_halfcell.py
+++ b/tests/renderable/test_halfcell.py
@@ -3,7 +3,7 @@ from rich.measure import Measurement
 from syrupy.assertion import SnapshotAssertion
 
 from tests.data import CONSOLE_OPTIONS, TEST_IMAGE
-from tests.utils import render
+from tests.utils import load_non_seekable_bytes_io, render
 
 
 def test_render(snapshot: SnapshotAssertion) -> None:
@@ -11,6 +11,18 @@ def test_render(snapshot: SnapshotAssertion) -> None:
 
     renderable = Image(TEST_IMAGE, width=4)
     assert render(renderable) == snapshot
+
+
+def test_render_non_seekable() -> None:
+    from textual_image.renderable.halfcell import Image
+
+    test_image = load_non_seekable_bytes_io(TEST_IMAGE)
+    renderable = Image(test_image)
+    assert test_image.read() == b""
+    assert render(renderable) == render(renderable)
+
+    test_image.close()
+    assert render(renderable) == render(renderable)
 
 
 def test_measure() -> None:

--- a/tests/renderable/test_sixel.py
+++ b/tests/renderable/test_sixel.py
@@ -8,7 +8,7 @@ from rich.measure import Measurement
 from syrupy.assertion import SnapshotAssertion
 
 from tests.data import CONSOLE_OPTIONS, TEST_IMAGE
-from tests.utils import render
+from tests.utils import load_non_seekable_bytes_io, render
 
 
 def test_render(snapshot: SnapshotAssertion) -> None:
@@ -16,6 +16,18 @@ def test_render(snapshot: SnapshotAssertion) -> None:
 
     renderable = Image(TEST_IMAGE, width=4)
     assert render(renderable) == snapshot
+
+
+def test_render_non_seekable() -> None:
+    from textual_image.renderable.sixel import Image
+
+    test_image = load_non_seekable_bytes_io(TEST_IMAGE)
+    renderable = Image(test_image)
+    assert test_image.read() == b""
+    assert render(renderable) == render(renderable)
+
+    test_image.close()
+    assert render(renderable) == render(renderable)
 
 
 def test_measure() -> None:

--- a/tests/renderable/test_tgp.py
+++ b/tests/renderable/test_tgp.py
@@ -10,7 +10,7 @@ from rich.measure import Measurement
 from syrupy.assertion import SnapshotAssertion
 
 from tests.data import CONSOLE_OPTIONS, TEST_IMAGE
-from tests.utils import render
+from tests.utils import load_non_seekable_bytes_io, render
 from textual_image._terminal import TerminalError
 
 
@@ -29,6 +29,20 @@ def test_overly_large() -> None:
     renderable = Image(TEST_IMAGE, width=2**32)
     with raises(ValueError):
         render(renderable)
+
+
+def test_render_non_seekable() -> None:
+    from textual_image.renderable.tgp import Image
+
+    test_image = load_non_seekable_bytes_io(TEST_IMAGE)
+    renderable = Image(test_image)
+    assert test_image.read() == b""
+    # encoding is not deterministic, so we don't compare the output
+    render(renderable)
+    render(renderable)
+
+    test_image.close()
+    render(renderable)
 
 
 def test_measure() -> None:

--- a/tests/renderable/test_unicode.py
+++ b/tests/renderable/test_unicode.py
@@ -3,7 +3,7 @@ from rich.measure import Measurement
 from syrupy.assertion import SnapshotAssertion
 
 from tests.data import CONSOLE_OPTIONS, TEST_IMAGE
-from tests.utils import render
+from tests.utils import load_non_seekable_bytes_io, render
 
 
 def test_render(snapshot: SnapshotAssertion) -> None:
@@ -11,6 +11,18 @@ def test_render(snapshot: SnapshotAssertion) -> None:
 
     renderable = Image(TEST_IMAGE, width=4)
     assert render(renderable) == snapshot
+
+
+def test_render_non_seekable() -> None:
+    from textual_image.renderable.unicode import Image
+
+    test_image = load_non_seekable_bytes_io(TEST_IMAGE)
+    renderable = Image(test_image)
+    assert test_image.read() == b""
+    assert render(renderable) == render(renderable)
+
+    test_image.close()
+    assert render(renderable) == render(renderable)
 
 
 def test_measure() -> None:

--- a/tests/test_pixeldata.py
+++ b/tests/test_pixeldata.py
@@ -10,6 +10,10 @@ def test_ensure_image() -> None:
     with ensure_image(TEST_IMAGE) as image:
         assert isinstance(image, PILImage.Image)
 
+    with open(TEST_IMAGE, "rb") as file:
+        with ensure_image(file) as image:
+            assert isinstance(image, PILImage.Image)
+
     with PILImage.open(TEST_IMAGE) as opened_image:
         with ensure_image(opened_image) as image:
             assert isinstance(image, PILImage.Image)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,9 @@
-from textual_image._utils import clamp, grouped
+import io
+from typing import Any
+
+import pytest
+
+from textual_image._utils import clamp, grouped, is_non_seekable_stream
 
 
 def test_grouped() -> None:
@@ -11,3 +16,43 @@ def test_clamp() -> None:
     assert clamp(75, 50, 100) == 75
     assert clamp(50, 50, 100) == 50
     assert clamp(100, 50, 100) == 100
+
+
+class UnseekableStream(io.BytesIO):
+    def seekable(self) -> bool:
+        return False
+
+
+class SeekableStream(io.BytesIO):
+    def seekable(self) -> bool:
+        return True
+
+
+class BrokenSeekableStream(io.BytesIO):
+    def seekable(self) -> bool:
+        raise RuntimeError("seekable not supported")
+
+
+class NoSeekableAttribute:
+    pass
+
+
+@pytest.mark.parametrize(
+    "stream, expected",
+    [
+        # seekable streams
+        (io.BytesIO(), False),
+        (io.StringIO(), False),
+        (SeekableStream(), False),
+        # non-seekable
+        (UnseekableStream(), True),
+        (BrokenSeekableStream(), False),
+        # not a stream
+        (NoSeekableAttribute(), False),
+        (123, False),
+        ("not a stream", False),
+        (None, False),
+    ],
+)
+def test_is_non_seekable_stream(stream: Any, expected: bool) -> None:
+    assert is_non_seekable_stream(stream) == expected

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,6 @@
 import io
+import pathlib
+from typing import IO
 from unittest.mock import patch
 
 from rich.console import Console, RenderableType
@@ -19,3 +21,18 @@ def render(renderable: RenderableType) -> str:
     with patch("sys.__stdout__", stdout):
         console.print(renderable)
     return stdout.getvalue()
+
+
+class NonSeekableBytesIO(io.BytesIO):
+    def seekable(self) -> bool:
+        return False
+
+    def seek(self, pos: int, whence: int = 0, /) -> int:
+        raise io.UnsupportedOperation("seek not allowed")
+
+
+def load_non_seekable_bytes_io(path: pathlib.Path) -> IO[bytes]:
+    with open(path, "rb") as file:
+        data = file.read()
+
+    return NonSeekableBytesIO(data)

--- a/tests/widget/test_base.py
+++ b/tests/widget/test_base.py
@@ -4,6 +4,7 @@ from PIL import Image as PILImage
 from PIL import ImageOps
 
 from tests.data import TEST_IMAGE, TEXTUAL_ENABLED
+from tests.utils import load_non_seekable_bytes_io
 
 
 @skipUnless(TEXTUAL_ENABLED, "Textual support disabled")
@@ -30,6 +31,29 @@ async def test_app() -> None:
             yield Image(TEST_IMAGE, classes="fixed")
             yield Image()
             yield Image(classes="auto")
+
+    app = TestApp()
+
+    # Not testing too much reasonable stuff, but, well, at least the code gets executed
+    async with app.run_test():
+        with PILImage.open(TEST_IMAGE) as test_image:
+            app.query_one(Image).image = ImageOps.flip(test_image)
+        assert app.query_one(Image).image != TEST_IMAGE
+
+
+@skipUnless(TEXTUAL_ENABLED, "Textual support disabled")
+async def test_unseekable_stream() -> None:
+    from textual.app import App, ComposeResult
+
+    from textual_image.widget import Image
+
+    image = Image(load_non_seekable_bytes_io(TEST_IMAGE))
+
+    class TestApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield image
+            yield image
+            yield image
 
     app = TestApp()
 

--- a/textual_image/_pixeldata.py
+++ b/textual_image/_pixeldata.py
@@ -3,15 +3,14 @@
 import io
 from base64 import b64encode
 from contextlib import nullcontext
-from pathlib import Path
-from typing import ContextManager, Iterable, Iterator, Literal, Tuple
+from typing import IO, ContextManager, Iterable, Iterator, Literal, Tuple
 
 from PIL import Image as PILImage
 
-from textual_image._utils import grouped
+from textual_image._utils import StrOrBytesPath, grouped
 
 
-def ensure_image(image: str | Path | PILImage.Image) -> ContextManager[PILImage.Image]:
+def ensure_image(image: StrOrBytesPath | IO[bytes] | PILImage.Image) -> ContextManager[PILImage.Image]:
     """Ensures value to be an `PIL.Image.Image`.
 
     This function accepts either a str or `pathlib.Path` of a path to an image file or a `PIL.Image.Image` instance.
@@ -32,7 +31,7 @@ def ensure_image(image: str | Path | PILImage.Image) -> ContextManager[PILImage.
 class PixelMeta:
     """Provides access to meta information of an image from a path or `PIL.Image.Image` instance."""
 
-    def __init__(self, image: str | Path | PILImage.Image) -> None:
+    def __init__(self, image: StrOrBytesPath | IO[bytes] | PILImage.Image) -> None:
         """Initializes a PixelMeta.
 
         Args:
@@ -46,7 +45,9 @@ class PixelMeta:
 class PixelData:
     """Provides access to pixel data from a path or `PIL.Image.Image` instance."""
 
-    def __init__(self, image: str | Path | PILImage.Image, mode: Literal["grayscale", "rgb"] | None = None) -> None:
+    def __init__(
+        self, image: StrOrBytesPath | IO[bytes] | PILImage.Image, mode: Literal["grayscale", "rgb"] | None = None
+    ) -> None:
         """Initializes a PixelData.
 
         Args:

--- a/textual_image/_utils.py
+++ b/textual_image/_utils.py
@@ -1,6 +1,9 @@
 """Utility functions."""
 
+import os
 from typing import Iterable, Iterator, TypeVar
+
+StrOrBytesPath = str | bytes | os.PathLike[str] | os.PathLike[bytes]
 
 T = TypeVar("T")
 

--- a/textual_image/_utils.py
+++ b/textual_image/_utils.py
@@ -1,9 +1,8 @@
 """Utility functions."""
 
+import io
 import os
-from typing import Iterable, Iterator, TypeVar
-
-StrOrBytesPath = str | bytes | os.PathLike[str] | os.PathLike[bytes]
+from typing import Any, Iterable, Iterator, TypeVar
 
 T = TypeVar("T")
 
@@ -45,3 +44,16 @@ def clamp(n: N, minimum: N, maximum: N) -> N:
         The constrained value.
     """
     return max(min(n, maximum), minimum)
+
+
+StrOrBytesPath = str | bytes | os.PathLike[str] | os.PathLike[bytes]
+
+
+def is_non_seekable_stream(stream: Any) -> bool:
+    if not isinstance(stream, io.IOBase) or not hasattr(stream, "seekable"):
+        return False
+
+    try:
+        return not stream.seekable()
+    except Exception:
+        return False

--- a/textual_image/renderable/_protocol.py
+++ b/textual_image/renderable/_protocol.py
@@ -1,16 +1,20 @@
-from pathlib import Path
-from typing import Protocol
+from typing import IO, Protocol
 
 from PIL import Image as PILImage
 from rich.console import Console, ConsoleOptions, RenderResult
 from rich.measure import Measurement
+
+from textual_image._utils import StrOrBytesPath
 
 
 class ImageRenderable(Protocol):
     """Protocol for `Image` renderables."""
 
     def __init__(
-        self, image: str | Path | PILImage.Image, width: int | str | None = None, height: int | str | None = None
+        self,
+        image: StrOrBytesPath | IO[bytes] | PILImage.Image,
+        width: int | str | None = None,
+        height: int | str | None = None,
     ) -> None: ...
     def __rich_console__(self, console: Console, options: ConsoleOptions) -> RenderResult: ...
     def __rich_measure__(self, console: Console, options: ConsoleOptions) -> Measurement: ...

--- a/textual_image/renderable/halfcell.py
+++ b/textual_image/renderable/halfcell.py
@@ -1,7 +1,6 @@
 """Provides a Rich Renderable to render images as colored half cells."""
 
-from pathlib import Path
-from typing import Tuple
+from typing import IO, Tuple
 
 from PIL import Image as PILImage
 from rich.color import Color
@@ -14,7 +13,7 @@ from rich.style import Style
 from textual_image._geometry import ImageSize
 from textual_image._pixeldata import PixelData
 from textual_image._terminal import get_cell_size
-from textual_image._utils import grouped
+from textual_image._utils import StrOrBytesPath, grouped
 
 
 def _map_pixel(pixel_value: Tuple[int, int, int]) -> Color:
@@ -33,12 +32,16 @@ class Image:
     """Rich Renderable to render images as colored half cells."""
 
     def __init__(
-        self, image: str | Path | PILImage.Image, width: int | str | None = None, height: int | str | None = None
+        self,
+        image: StrOrBytesPath | IO[bytes] | PILImage.Image,
+        width: int | str | None = None,
+        height: int | str | None = None,
     ) -> None:
         """Initialized the `Image`.
 
         Args:
-            image: Path to an image file or `PIL.Image.Image` instance with the image data to render.
+            image: Path to an image file, a byte stream containing image data, or `PIL.Image.Image` instance with the
+                   image data to render.
             width: Width specification to render the image.
                 See `textual_image.geometry.ImageSize` for details about possible values.
             height: height specification to render the image.

--- a/textual_image/renderable/sixel.py
+++ b/textual_image/renderable/sixel.py
@@ -1,7 +1,7 @@
 """Provides a Rich Renderable to render images as Sixels (https://en.wikipedia.org/wiki/Sixel)."""
 
 import sys
-from pathlib import Path
+from typing import IO
 
 from PIL import Image as PILImage
 from rich.console import Console, ConsoleOptions, RenderResult
@@ -13,6 +13,7 @@ from textual_image._geometry import ImageSize
 from textual_image._pixeldata import PixelData
 from textual_image._sixel import image_to_sixels
 from textual_image._terminal import TerminalError, capture_terminal_response, get_cell_size
+from textual_image._utils import StrOrBytesPath
 
 # Random no-op control code to prevent Rich from messing with our data
 _NULL_CONTROL = [(ControlType.CURSOR_FORWARD, 0)]
@@ -22,12 +23,16 @@ class Image:
     """Rich Renderable to render images as Sixels (https://en.wikipedia.org/wiki/Sixel)."""
 
     def __init__(
-        self, image: str | Path | PILImage.Image, width: int | str | None = None, height: int | str | None = None
+        self,
+        image: StrOrBytesPath | IO[bytes] | PILImage.Image,
+        width: int | str | None = None,
+        height: int | str | None = None,
     ) -> None:
         """Initialized the `Image`.
 
         Args:
-            image: Path to an image file or `PIL.Image.Image` instance with the image data to render.
+            image: Path to an image file, a byte stream containing image data, or `PIL.Image.Image` instance with the
+                   image data to render.
             width: Width specification to render the image.
                 See `textual_image.geometry.ImageSize` for details about possible values.
             height: height specification to render the image.

--- a/textual_image/renderable/tgp.py
+++ b/textual_image/renderable/tgp.py
@@ -3,9 +3,8 @@
 import logging
 import sys
 from itertools import count
-from pathlib import Path
 from random import randint
-from typing import Iterator
+from typing import IO, Iterator
 
 from PIL import Image as PILImage
 from rich.console import Console, ConsoleOptions, RenderResult
@@ -16,6 +15,7 @@ from rich.style import Style
 from textual_image._geometry import ImageSize
 from textual_image._pixeldata import PixelData
 from textual_image._terminal import TerminalError, capture_terminal_response, get_cell_size
+from textual_image._utils import StrOrBytesPath
 
 logger = logging.getLogger(__name__)
 
@@ -82,12 +82,16 @@ class Image:
     _image_id_counter = count(randint(1, 2**32))
 
     def __init__(
-        self, image: str | Path | PILImage.Image, width: int | str | None = None, height: int | str | None = None
+        self,
+        image: StrOrBytesPath | IO[bytes] | PILImage.Image,
+        width: int | str | None = None,
+        height: int | str | None = None,
     ) -> None:
         """Initialized the `Image`.
 
         Args:
-            image: Path to an image file or `PIL.Image.Image` instance with the image data to render.
+            image: Path to an image file, a byte stream containing image data, or `PIL.Image.Image` instance with the
+                   image data to render.
             width: Width specification to render the image.
                 See `textual_image.geometry.ImageSize` for details about possible values.
             height: height specification to render the image.

--- a/textual_image/renderable/unicode.py
+++ b/textual_image/renderable/unicode.py
@@ -1,7 +1,6 @@
 """Provides a Rich Renderable to render images as grayscale unicode characters."""
 
-from pathlib import Path
-from typing import cast
+from typing import IO, cast
 
 from PIL import Image as PILImage
 from rich.console import Console, ConsoleOptions, RenderResult
@@ -11,7 +10,7 @@ from rich.segment import Segment
 from textual_image._geometry import ImageSize
 from textual_image._pixeldata import PixelData
 from textual_image._terminal import get_cell_size
-from textual_image._utils import clamp
+from textual_image._utils import StrOrBytesPath, clamp
 
 _CHARACTERS = [
     "█",  # FULL BLOCK
@@ -42,12 +41,16 @@ class Image:
     """Rich Renderable to render images as grayscale unicode characters."""
 
     def __init__(
-        self, image: str | Path | PILImage.Image, width: int | str | None = None, height: int | str | None = None
+        self,
+        image: StrOrBytesPath | IO[bytes] | PILImage.Image,
+        width: int | str | None = None,
+        height: int | str | None = None,
     ) -> None:
         """Initialized the `Image`.
 
         Args:
-            image: Path to an image file or `PIL.Image.Image` instance with the image data to render.
+            image: Path to an image file, a byte stream containing image data, or `PIL.Image.Image` instance with the
+                   image data to render.
             width: Width specification to render the image.
                 See `textual_image.geometry.ImageSize` for details about possible values.
             height: height specification to render the image.

--- a/textual_image/widget/_base.py
+++ b/textual_image/widget/_base.py
@@ -1,7 +1,6 @@
 """Provides a Textual `Widget` to render images in the terminal."""
 
-from pathlib import Path
-from typing import Literal, Tuple, Type, cast
+from typing import IO, Literal, Tuple, Type, cast
 
 from PIL import Image as PILImage
 from textual.app import RenderResult
@@ -13,6 +12,7 @@ from typing_extensions import override
 from textual_image._geometry import ImageSize
 from textual_image._pixeldata import PixelMeta
 from textual_image._terminal import get_cell_size
+from textual_image._utils import StrOrBytesPath
 from textual_image.renderable._protocol import ImageRenderable
 
 
@@ -45,7 +45,7 @@ class Image(Widget):
 
     def __init__(
         self,
-        image: str | Path | PILImage.Image | None = None,
+        image: StrOrBytesPath | IO[bytes] | PILImage.Image | None = None,
         *,
         name: str | None = None,
         id: str | None = None,
@@ -55,7 +55,8 @@ class Image(Widget):
         """Initializes the `Image`.
 
         Args:
-            image: Path to an image file or `PIL.Image.Image` instance with the image data to render.
+            image: Path to an image file, a byte stream containing image data, or `PIL.Image.Image` instance with the
+                   image data to render.
             name: The name of the widget.
             id: The ID of the widget in the DOM.
             classes: The CSS classes for the widget.
@@ -63,14 +64,14 @@ class Image(Widget):
         """
         super().__init__(name=name, id=id, classes=classes, disabled=disabled)
         self._renderable: ImageRenderable | None = None
-        self._image: str | Path | PILImage.Image | None = None
+        self._image: StrOrBytesPath | IO[bytes] | PILImage.Image | None = None
         self._image_width: int = 0
         self._image_height: int = 0
 
         self.image = image
 
     @property
-    def image(self) -> str | Path | PILImage.Image | None:
+    def image(self) -> StrOrBytesPath | IO[bytes] | PILImage.Image | None:
         """The image to render.
 
         Path to an image file or `PIL.Image.Image` instance with the image data to render.
@@ -78,7 +79,7 @@ class Image(Widget):
         return self._image
 
     @image.setter
-    def image(self, value: str | Path | PILImage.Image | None) -> None:
+    def image(self, value: StrOrBytesPath | IO[bytes] | PILImage.Image | None) -> None:
         if self._renderable:
             self._renderable.cleanup()
             self._renderable = None

--- a/textual_image/widget/sixel.py
+++ b/textual_image/widget/sixel.py
@@ -1,8 +1,7 @@
 """Provides a Textual `Widget` to render images as Sixels (<https://en.wikipedia.org/wiki/Sixel>) in the terminal."""
 
 import logging
-from pathlib import Path
-from typing import Iterable, NamedTuple
+from typing import IO, Iterable, NamedTuple
 
 from PIL import Image as PILImage
 from rich.console import Console, ConsoleOptions, RenderResult
@@ -20,6 +19,7 @@ from textual_image._geometry import ImageSize
 from textual_image._pixeldata import PixelData
 from textual_image._sixel import image_to_sixels
 from textual_image._terminal import CellSize, get_cell_size
+from textual_image._utils import StrOrBytesPath
 from textual_image.widget._base import Image as BaseImage
 
 logger = logging.getLogger(__name__)
@@ -29,7 +29,7 @@ _NULL_STYLE = Style()
 
 
 class _CachedSixels(NamedTuple):
-    image: str | Path | PILImage.Image
+    image: StrOrBytesPath | IO[bytes] | PILImage.Image
     content_crop: Region
     content_size: Size
     terminal_sizes: CellSize
@@ -37,7 +37,7 @@ class _CachedSixels(NamedTuple):
 
     def is_hit(
         self,
-        image: str | Path | PILImage.Image,
+        image: StrOrBytesPath | IO[bytes] | PILImage.Image,
         content_crop: Region,
         content_size: Size,
         terminal_sizes: CellSize,
@@ -60,7 +60,10 @@ class _NoopRenderable:
     """
 
     def __init__(
-        self, image: str | Path | PILImage.Image, width: int | str | None = None, height: int | str | None = None
+        self,
+        image: StrOrBytesPath | IO[bytes] | PILImage.Image,
+        width: int | str | None = None,
+        height: int | str | None = None,
     ) -> None:
         pass
 
@@ -105,7 +108,7 @@ class _ImageSixelImpl(Widget, can_focus=False, inherit_css=False):
     @override
     def __init__(
         self,
-        image: str | Path | PILImage.Image | None = None,
+        image: StrOrBytesPath | IO[bytes] | PILImage.Image | None = None,
     ) -> None:
         super().__init__()
         self.image = image


### PR DESCRIPTION
This PR introduces support for handling image data from byte streams, in addition to file paths and `PIL.Image.Image` instances.

The following changes were made to support byte stream handling:

- Updated the `ensure_image` function to accept `StrOrBytesPath | IO[bytes]`, aligning it with `PIL.Image` support, and added corresponding unit tests.
- Updated type hints to support `StrOrBytesPath | IO[bytes] | PILImage.Image` in relevant methods.

Since `ensure_image` internally uses `PILImage.open`, which already supports byte streams. This PR primarily focuses on updating type hints for better flexibility.

It is particularly useful for images that come from streams opened by other libraries or from network sources.