### PR TITLE
fix: no screen error fallback

### DIFF
--- a/textual_image/widget/sixel.py
+++ b/textual_image/widget/sixel.py
@@ -13,6 +13,7 @@ from textual.app import ComposeResult
 from textual.geometry import Region, Size
 from textual.strip import Strip
 from textual.widget import Widget
+from textual.dom import NoScreen
 from typing_extensions import override
 
 from textual_image._geometry import ImageSize
@@ -124,7 +125,10 @@ class _ImageSixelImpl(Widget, can_focus=False, inherit_css=False):
     def render_lines(self, crop: Region) -> list[Strip]:
         # We don't render anything if the screen isn't active. Textual may try to tint the widget which leads to weird
         # effects.
-        if not self.image or not self.screen.is_active:
+        try:
+            if not self.image or not self.screen.is_active:
+                return []
+        except NoScreen:# if no screen, return empty list
             return []
 
         # Inject the sixel data. We can only do it here because we don't know the crop region before.

--- a/textual_image/widget/sixel.py
+++ b/textual_image/widget/sixel.py
@@ -128,7 +128,7 @@ class _ImageSixelImpl(Widget, can_focus=False, inherit_css=False):
         try:
             if not self.image or not self.screen.is_active:
                 return []
-        except NoScreen:# if no screen, return empty list
+        except NoScreen:  # if no screen, return empty list
             return []
 
         # Inject the sixel data. We can only do it here because we don't know the crop region before.

--- a/textual_image/widget/sixel.py
+++ b/textual_image/widget/sixel.py
@@ -10,10 +10,10 @@ from rich.measure import Measurement
 from rich.segment import ControlType, Segment
 from rich.style import Style
 from textual.app import ComposeResult
+from textual.dom import NoScreen
 from textual.geometry import Region, Size
 from textual.strip import Strip
 from textual.widget import Widget
-from textual.dom import NoScreen
 from typing_extensions import override
 
 from textual_image._geometry import ImageSize


### PR DESCRIPTION
Fix intermittent NoScreen when compositor probes unmounted Sixel widgets.

When rapidly replacing Sixel widgets, compositor may call render_lines on widgets
that are not yet attached to a Screen, raising `textual.dom.NoScreen`. This change
defensively checks for a screen (and catches `NoScreen`) and returns an empty
render list if the widget is not ready. Adds regression test to ensure no
exception is raised.

Closes: #73